### PR TITLE
fix problem with plotting in chap6 forecast1.py

### DIFF
--- a/chapter-6/forecast1.py
+++ b/chapter-6/forecast1.py
@@ -22,7 +22,7 @@ class ForecastFlow(FlowSpec):
         from sktime.utils.plotting import plot_series
         from io import BytesIO
         buf = BytesIO()
-        fig, _ = plot_series(self.pd_past5days, labels=['past5days'])
+        fig, _ = plot_series(self.pd_past5days.sort_index(axis=0), labels=['past5days'])
         fig.savefig(buf)
         self.plot = buf.getvalue()
         self.next(self.end)


### PR DESCRIPTION
ValueError: The (time) index must be sorted (monotonically increasing), but found: DatetimeIndex(['2022-08-24 20:00:00', '2022-08-24 21:00:00'