### PR TITLE
Added boto3

### DIFF
--- a/chapter-5/kmeans_flow_v2.py
+++ b/chapter-5/kmeans_flow_v2.py
@@ -1,6 +1,6 @@
 from metaflow import FlowSpec, step, Parameter, resources, conda_base, profile
 
-@conda_base(python='3.8.3', libraries={'scikit-learn': '0.24.1'})
+@conda_base(python='3.8.3', libraries={'scikit-learn': '0.24.1', 'boto3':'1.24.77'})
 class KmeansFlow(FlowSpec):
 
     num_docs = Parameter('num-docs', help='Number of documents', default=1000000)


### PR DESCRIPTION
When running locally, without boto3 as the key, the task was failing: `You need to install 'boto3' in order to use S3.` Unsure if this is the problem when running with AWS Batch.